### PR TITLE
support use google cloud api to enhance translate quality

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ function translate(text, opts, gotopts) {
     opts.from = opts.from || 'auto';
     opts.to = opts.to || 'en';
 
-    if (opts.useGoogleAPIs) {
-        let key = opts.googleAPIsKey || "";
+    if (opts.useGoogleCloudApis) {
+        let key = opts.googleCloudAPIsKey || "";
         opts.url = "https://translation.googleapis.com/language/translate/v2?key=" + key;
     }
     else {
@@ -45,7 +45,7 @@ function translate(text, opts, gotopts) {
     opts.to = languages.getCode(opts.to);
 
     var url = opts.url;
-    if (opts.useGoogleAPIs) {
+    if (opts.useGoogleCloudApis) {
         let payload = {
             "q": text,
             "target": opts.to,

--- a/index.js
+++ b/index.js
@@ -32,24 +32,88 @@ function translate(text, opts, gotopts) {
 
     opts.from = opts.from || 'auto';
     opts.to = opts.to || 'en';
-    opts.url = opts.url || 'https://translate.google.cn';
+
+    if (opts.useGoogleAPIs) {
+        let key = opts.googleAPIsKey || "";
+        opts.url = "https://translation.googleapis.com/language/translate/v2?key=" + key;
+    }
+    else {
+        opts.url = opts.url || 'https://translate.google.cn';
+    }
 
     opts.from = languages.getCode(opts.from);
     opts.to = languages.getCode(opts.to);
 
     var url = opts.url;
-    return got(url, gotopts).then(function (res) {
-        var data = {
-            'rpcids': 'MkEWBc',
-            'f.sid': extract('FdrFJe', res),
-            'bl': extract('cfb2h', res),
-            'hl': 'en-US',
-            'soc-app': 1,
-            'soc-platform': 1,
-            'soc-device': 1,
-            '_reqid': Math.floor(1000 + (Math.random() * 9000)),
-            'rt': 'c'
-        };
+    if (opts.useGoogleAPIs) {
+        let payload = {
+            "q": text,
+            "target": opts.to,
+            "format": "text"
+        }
+
+        gotopts.body = JSON.stringify(payload);
+        gotopts.headers = gotopts.headers || {};
+        gotopts.headers['content-type'] = 'application/json;charset=UTF-8';
+
+        return got.post(url, gotopts).then(function (res) {
+            var result = {
+                text: '',
+                pronunciation: '',
+                candidates: [],
+                from: {
+                    language: {
+                        didYouMean: false,
+                        iso: ''
+                    },
+                    text: {
+                        autoCorrected: false,
+                        value: '',
+                        didYouMean: false
+                    }
+                },
+                raw: ''
+            };
+
+            let resJson = {};
+            try {
+                resJson = JSON.parse(res.body);
+            } catch (e) {
+                return result;
+            }
+
+            if (!resJson || !resJson.data || !resJson.data.translations || 0 == resJson.data.translations.length) {
+                return result;
+            }
+
+            result.text = resJson.data.translations[0].translatedText || '';
+            result.from.language.iso = opts.from;
+            result.from.text.value = text;
+            result.raw = resJson;
+
+            return result;
+        }).catch(function (err) {
+            err.message += `\nUrl: ${url}\nPayload: ${JSON.stringify(payload)}`;
+            if (err.statusCode !== undefined && err.statusCode !== 200) {
+                err.code = 'BAD_REQUEST';
+            } else {
+                err.code = 'BAD_NETWORK';
+            }
+            throw err;
+        });
+    } else {
+        return got(url, gotopts).then(function (res) {
+            var data = {
+                'rpcids': 'MkEWBc',
+                'f.sid': extract('FdrFJe', res),
+                'bl': extract('cfb2h', res),
+                'hl': 'en-US',
+                'soc-app': 1,
+                'soc-platform': 1,
+                'soc-device': 1,
+                '_reqid': Math.floor(1000 + (Math.random() * 9000)),
+                'rt': 'c'
+            };
 
         return data;
     }).then(function (data) {


### PR DESCRIPTION
目前使用的api翻译质量较差，例如翻译“开车的迪迦奥特曼”，现在会翻译成“Diga Altman who drives”

现在支持使用Google Cloud API的翻译api，会正确的翻译成“Ultraman Tiga driving”

用法：

await translator(text, {
from: lang.from == 'auto' ? undefined : lang.from,
to: lang.to,
useGoogleAPIs: true,
googleAPIsKey: "your Google Cloud APIs key",
})

Google Cloud APIs key 申请参考 https://cloud.google.com/docs/authentication/api-keys